### PR TITLE
3.4 cpu py39 v1.1 (#146)

### DIFF
--- a/spark/processing/3.4/py3/docker/py39/Dockerfile.cpu
+++ b/spark/processing/3.4/py3/docker/py39/Dockerfile.cpu
@@ -8,7 +8,7 @@ RUN yum clean all \
     && yum update -y \
     && yum update -y kernel kernel-headers kernel-devel \
     && yum install -y awscli bigtop-utils curl gcc gzip unzip zip gunzip tar wget liblapack* libblas* libopencv* libopenblas* \
-    && yum update -y libcurl curl tar vim-data vim-minimal ncurses-libs ncurses ncurses-base ncurses-compat-libs binutils nss-softokn-freebl avahi-libs avahi dbus dbus-libs python python-libs python-devel gstreamer-plugins-base python-pillow
+    && yum update -y cpio glib2 libcurl curl tar vim-data vim-minimal ncurses-libs ncurses ncurses-base ncurses-compat-libs binutils nss-softokn-freebl avahi-libs avahi dbus dbus-libs python python-libs python-devel gstreamer-plugins-base python-pillow
 
 # Taken from EMR https://tiny.amazon.com/1dp4p55nm/codeamazpackAwsCblob8b00src
 RUN amazon-linux-extras enable corretto8 nginx1 \


### PR DESCRIPTION
* release Spark 3.4-cpu-py39-v1.1

* make fixes for hadoop-aws integration with aws-java-sdk-v2

* fix lint errors

* Fix test expectations for a job failed with AlgorithError as we ramp up traffic for V2 stack

* updating OS libs to address more CVEs

---------